### PR TITLE
修复PHP警告三元表达式警告

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -222,7 +222,7 @@ class Builder
      */
     public function create(array $data, $id = null, $key = 'id'): object
     {
-        $id = $id ? $id : isset($data[$key]) ? $data[$key] : Uuid::uuid6()->toString();
+        $id = $id ? $id : (isset($data[$key]) ? $data[$key] : Uuid::uuid6()->toString());
 
         $result = $this->runQuery(
             $this->query->getGrammar()->compileCreate($this->query, $id, $data),


### PR DESCRIPTION
Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`